### PR TITLE
point people to the Forum instead of Slack

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -10,7 +10,7 @@ import {
 import {
   graphcoolConfigFilePath,
   systemAPIEndpoint,
-  contactUsInSlackMessage,
+  contactUs,
   statusEndpoint,
 } from '../utils/constants'
 import 'isomorphic-fetch'
@@ -400,7 +400,7 @@ export function parseErrors(response: any): APIError[] {
 
 export function generateErrorOutput(apiErrors: APIError[]): string {
   const lines = apiErrors.map(error => `${error.message} (Request ID: ${error.requestId})`)
-  const output = `\n${lines.join('\n')}\n\n${contactUsInSlackMessage}`
+  const output = `\n${lines.join('\n')}\n\n${contactUs}`
   return output
 }
 

--- a/src/system/StdOut.ts
+++ b/src/system/StdOut.ts
@@ -1,5 +1,5 @@
 import { Out } from '../types'
-import { setDebugMessage, contactUsInSlackMessage } from '../utils/constants'
+import { setDebugMessage, contactUs } from '../utils/constants'
 import { makePartsEnclodesByCharacterBold } from '../utils/utils'
 import * as chalk from 'chalk'
 import figures = require('figures')
@@ -46,7 +46,7 @@ export default class StdOut implements Out {
       console.error(JSON.stringify(error))
     }
 
-    console.error(`\n${setDebugMessage}\n${contactUsInSlackMessage}\n`)
+    console.error(`\n${setDebugMessage}\n${contactUs}\n`)
 
     await new Promise(resolve => Raven.captureException(error, resolve))
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -411,8 +411,8 @@ Are you absolutely sure you want to delete these projects? ${chalk.bold(`This op
  * Terminal output: general
  */
 
-export const contactUsInSlackMessage = `\
- * Get in touch if you need help: http://slack.graph.cool/`
+export const contactUs = `\
+ * Get in touch if you need help: https://github.com/graphcool/graphcool-cli`
 
 export const setDebugMessage = `\
  * You can enable additional output by setting \`export DEBUG=graphcool\` and rerunning the command.

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -412,7 +412,7 @@ Are you absolutely sure you want to delete these projects? ${chalk.bold(`This op
  */
 
 export const contactUs = `\
- * Get in touch if you need help: https://github.com/graphcool/graphcool-cli`
+ * Get in touch if you need help: https://www.graph.cool/forum`
 
 export const setDebugMessage = `\
  * You can enable additional output by setting \`export DEBUG=graphcool\` and rerunning the command.

--- a/tests/helpers/test_out.ts
+++ b/tests/helpers/test_out.ts
@@ -1,7 +1,7 @@
 import { Out } from '../../src/types'
 import * as fs from 'fs'
 import * as chalk from 'chalk'
-import {setDebugMessage, contactUsInSlackMessage} from '../../src/utils/constants'
+import {setDebugMessage, contactUs} from '../../src/utils/constants'
 import figures = require('figures')
 
 export default class TestOut implements Out {
@@ -39,7 +39,7 @@ export default class TestOut implements Out {
       this.write(`${message}\n`)
     }
 
-    this.write(`\n${setDebugMessage}\n${contactUsInSlackMessage}\n`)
+    this.write(`\n${setDebugMessage}\n${contactUs}\n`)
   }
 
 }


### PR DESCRIPTION
new error messages will like like this:

```
* You can enable additional output by setting `export DEBUG=graphcool` and rerunning the command.
* Open an issue on GitHub: https://github.com/graphcool/graphcool-cli.
* Get in touch if you need help: http://www.graph.cool/forum
```