### PR TITLE
force consistent casing in file names

### DIFF
--- a/packages/graphcool-cli-core/tsconfig.json
+++ b/packages/graphcool-cli-core/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
     "strictNullChecks": true,
     "sourceMap": true,
     "outDir": "dist",

--- a/packages/graphcool-cli-engine/src/CLI.test.ts
+++ b/packages/graphcool-cli-engine/src/CLI.test.ts
@@ -1,4 +1,4 @@
-import {CLI} from './Cli'
+import {CLI} from './CLI'
 
 jest.unmock('fs-extra')
 

--- a/packages/graphcool-cli-engine/src/Command.test.ts
+++ b/packages/graphcool-cli-engine/src/Command.test.ts
@@ -2,7 +2,7 @@
 import 'source-map-support/register'
 
 import {Command as Base} from './Command'
-import {flags as Flags} from './flags'
+import {flags as Flags} from './Flags'
 import nock from 'nock'
 import { Config } from './Config'
 

--- a/packages/graphcool-cli-engine/src/Plugin/Plugins.ts
+++ b/packages/graphcool-cli-engine/src/Plugin/Plugins.ts
@@ -1,5 +1,5 @@
 
-import Plugin from './plugin'
+import Plugin from './Plugin'
 import * as uniqby from 'lodash.uniqby'
 import Lock from './Lock'
 import { Output } from '../Output/index'

--- a/packages/graphcool-cli-engine/tsconfig.json
+++ b/packages/graphcool-cli-engine/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
     "strictNullChecks": true,
     "sourceMap": true,
     "outDir": "dist",

--- a/packages/graphcool-cli/tsconfig.json
+++ b/packages/graphcool-cli/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
     "strictNullChecks": true,
     "sourceMap": true,
     "outDir": "dist",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
     "preserveConstEnums": true,
     "strictNullChecks": true,
     "moduleResolution": "node",


### PR DESCRIPTION
Avoids file referencing issues on case-sensitive file systems.

Closes #266.